### PR TITLE
Add sanity test and fix for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,10 @@ install:
  - pip install pycodestyle pyflakes
 
 script:
- # Pretend tests
+ # Tests
+ - python test_bbcrealtime.py
+
+ # Static analysis
  - pyflakes .
  - pycodestyle --statistics --count .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ sudo: false
 
 install:
  - pip install pycodestyle pyflakes
+ - pip install -r requirements.txt
 
 script:
  # Tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,10 @@ language: python
 python:
  - pypy
  - pypy3
- - 2.6
  - 2.7
- - 3.2
- - 3.3
  - 3.4
  - 3.5
+ - 3.6
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,12 @@ python:
 sudo: false
 
 install:
- - pip install pep8 pyflakes
+ - pip install pycodestyle pyflakes
 
 script:
  # Pretend tests
  - pyflakes .
- - pep8 --statistics --count .
+ - pycodestyle --statistics --count .
 
 matrix:
   fast_finish: true

--- a/bbcrealtime.py
+++ b/bbcrealtime.py
@@ -41,7 +41,7 @@ def bbcrealtime(station):
     url = "https://polling.bbc.co.uk/radio/realtime/{0}.jsonp".format(station)
     try:
         r = requests.get(url)
-        response = _jsonp_to_json(r.content)
+        response = _jsonp_to_json(r.text)
         realtime = json.loads(response)['realtime']
     except requests.exceptions.ConnectionError:
         return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/test_bbcrealtime.py
+++ b/test_bbcrealtime.py
@@ -1,0 +1,36 @@
+# encoding: utf-8
+from __future__ import print_function, unicode_literals
+
+import unittest
+
+import bbcrealtime
+
+
+class TestBbcRealtime(unittest.TestCase):
+
+    def test_something(self):
+        # Arrange
+        stations = ["bbc6music", "bbcradio1", "bbcradio2", "bbc1xtra"]
+
+        for station in stations:
+            # Hopefully at least one station is currently playing something
+            # and not returning None
+
+            # Act
+            realtime = bbcrealtime.nowplaying(station)
+
+            if realtime is not None:
+                break
+
+        # Assert
+        self.assertIsNotNone(realtime)
+        self.assertIn("start", realtime)
+        self.assertIn("end", realtime)
+        self.assertGreater(realtime["end"], 1520157840)
+        self.assertGreater(realtime["end"], realtime["start"])
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+# End of  file


### PR DESCRIPTION

> When you make a request, Requests makes educated guesses about the encoding of the response based on the HTTP headers. The text encoding guessed by Requests is used when you access r.text.

http://docs.python-requests.org/en/master/user/quickstart/#response-content
https://stackoverflow.com/a/41068125/724176